### PR TITLE
Fixed an error in the doexport view of the module

### DIFF
--- a/modules/bccie/doexport.php
+++ b/modules/bccie/doexport.php
@@ -105,7 +105,7 @@ switch($export_type){
 
 header("Content-Disposition: attachment; filename=$filename");
 
-$export_string=$parser->exportInformationCollection( $collections, $attributes_to_export, $seperation_char, $export_type, $objectID);
+$export_string=$parser->exportInformationCollection( $collections, $attributes_to_export, $seperation_char, $export_type );
 
 echo($export_string);
 


### PR DESCRIPTION
Line 108 had an error; the exportInformationCollection() method of the parser does not accept $objectID as the last parameter.
