### PR TITLE
 Fix UTF-8 BOM for Excel

### DIFF
--- a/modules/bccie/doexport.php
+++ b/modules/bccie/doexport.php
@@ -124,6 +124,7 @@ switch ( $export_type )
 }
 
 header( "Content-Disposition: attachment; filename=$filename" );
+echo "\xEF\xBB\xBF";
 
 $export_string = $parser->exportInformationCollection(
                         $collections,


### PR DESCRIPTION
Exported files (csv) can be opened in Excel as UTF-8, no more problems with special characters.
