### PR TITLE
Add additional handlers

### DIFF
--- a/classes/handlers/ezenhancedobjectrelationhandler.php
+++ b/classes/handlers/ezenhancedobjectrelationhandler.php
@@ -19,7 +19,7 @@ class ezenhancedobjectrelationHandler extends BaseHandler
         $id_list = $content['id_list'];
 
         $ini = eZINI::instance( "export.ini" );
-        if ( $ini->variable( "ezenhancedobjectrelation", "OutputRelatedObjectNames" ) )
+        if ( $ini->variable( "ezenhancedobjectrelation", "OutputRelatedObjectNames" )  !== 'false' )
         {
             $names = array();
             foreach ( $id_list as $id )

--- a/classes/handlers/ezobjectrelationhandler.php
+++ b/classes/handlers/ezobjectrelationhandler.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * File containing the ezenhancedobjectrelationhandler class.
+ *
+ * @copyright Copyright (C) 1999 - 2014 Brookins Consulting. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2 (or any later version)
+ * @version //autogentag//
+ * @package bccie
+ */
+
+
+class eZObjectrelationHandler extends BaseHandler
+{
+
+    function exportAttribute( &$attribute, $seperationChar )
+    {
+        $content = $attribute->content();
+        $ini = eZINI::instance( "export.ini" );
+        if ( $ini->variable( "ezobjectrelation", "OutputRelatedObjectNames" ) !== 'false' )
+        {
+            return $this->escape( $content->name(), $seperationChar );
+        }
+        else
+        {
+            return $this->escape( $content->attribute('id' ), $seperationChar );
+        }
+    }
+}
+
+?>

--- a/classes/handlers/owenhancedselectionhandler.php
+++ b/classes/handlers/owenhancedselectionhandler.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the owenhancedselectionhandler class.
+ *
+ * @copyright Copyright (C) 1999 - 2014 Brookins Consulting. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2 (or any later version)
+ * @version //autogentag//
+ * @package bccie
+ */
+
+class OWEnhancedselectionHandler extends BaseHandler
+{
+
+    function exportAttribute( &$attribute, $seperationChar )
+    {
+        $content = $attribute->attribute('content');
+        return $this->escape( $content['to_string'], $seperationChar );
+    }
+
+}
+
+?>

--- a/settings/export.ini.append.php
+++ b/settings/export.ini.append.php
@@ -18,7 +18,8 @@ ExportableDatatypes[]=ezcountry
 ExportableDatatypes[]=eztime
 ExportableDatatypes[]=ezdate
 ExportableDatatypes[]=ezdatetime
-
+ExportableDatatypes[]=ezobjectrelation
+ExportableDatatypes[]=owenhancedselection
 
 # All handlerfiles are sought in the base directory,
 # extension/bccie/modules/bccie/,
@@ -91,5 +92,14 @@ HandlerClass=eZTimeHandler
 [ezdate]
 HandlerFile=ezdatehandler.php
 HandlerClass=eZDateHandler
+
+[ezobjectrelation]
+HandlerFile=ezobjectrelationhandler.php
+HandlerClass=eZObjectrelationHandler
+OutputRelatedObjectNames=true
+
+[owenhancedselection]
+HandlerFile=owenhancedselectionhandler.php
+HandlerClass=OWEnhancedselectionHandler
 
 */ ?>


### PR DESCRIPTION
Hi,

Here is a pull-request to add additional handlers :
 - ezobjectrelation : this datatype doesn't support information collection, but this handler can be useful to use csv parser for general csv exports (like general content objects)
 - owenhancedselection : this datatype is an enhancement of ezselection ( see https://github.com/Open-Wide/OWEnhancedSelection for details )

Cheers,
Simon Boyer