### PR TITLE
UTF-8 encoding problem solved for excel on mac.

### DIFF
--- a/classes/handlers/smileobjectrelationlisthandler.php
+++ b/classes/handlers/smileobjectrelationlisthandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the smileobjectrelationlist class.
+ * File containing the smileobjectrelationlistHandler class.
  *
  */
 class smileobjectrelationlistHandler extends BaseHandler

--- a/classes/handlers/smileobjectrelationlisthandler.php
+++ b/classes/handlers/smileobjectrelationlisthandler.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File containing the smileobjectrelationlist class.
+ *
+ */
+class smileobjectrelationlistHandler extends BaseHandler
+{
+    function exportAttribute( &$attribute, $seperationChar )
+    {
+        eZDebug::writeDebug( $attribute, "SMILE" );
+        $content = $attribute->content();
+
+        $relation_list = $content['relation_list'];
+        eZDebug::writeDebug( $content, "SMILE" );
+
+        $names = array();
+        foreach ( $relation_list as $relation )
+        {
+            $object = eZContentObject::fetch( $relation['contentobject_id'] );
+            $names[] = $object->name();
+        }
+        return $this->escape( join( " ", $names ), $seperationChar );
+    }
+}

--- a/classes/parser.php
+++ b/classes/parser.php
@@ -150,19 +150,17 @@ class Parser
 
         if ( $this->getCreationDate() === true )
         {
-            //TODO: i18n
-                array_push(
-                    $resultstring,
-                    ezpI18n::tr( "design/bccie/export", "created" )
-                );
+            array_push(
+                $resultstring,
+                ezpI18n::tr( "design/bccie/export", "created" )
+            );
         }
         if ( $this->getModificationDate() === true )
         {
-            //TODO: i18n
-                array_push(
-                    $resultstring,
-                    ezpI18n::tr( "design/bccie/export", "modified" )
-                );
+            array_push(
+                $resultstring,
+                ezpI18n::tr( "design/bccie/export", "modified" )
+            );
         }
 
         return $resultstring;

--- a/classes/parser.php
+++ b/classes/parser.php
@@ -18,6 +18,8 @@ class Parser
     var $handlerMap = array();
     var $exportableDatatypes;
     var $contentClassCollectorAttributes;
+    var $exportCreationDate;
+    var $exportModificationDate;
 
     function Parser( $objectID = false )
     {
@@ -146,6 +148,23 @@ class Parser
             }
         }
 
+        if ( $this->getCreationDate() === true )
+        {
+            //TODO: i18n
+                array_push(
+                    $resultstring,
+                    ezpI18n::tr( "design/bccie/export", "created" )
+                );
+        }
+        if ( $this->getModificationDate() === true )
+        {
+            //TODO: i18n
+                array_push(
+                    $resultstring,
+                    ezpI18n::tr( "design/bccie/export", "modified" )
+                );
+        }
+
         return $resultstring;
     }
 
@@ -192,6 +211,16 @@ class Parser
             }
         }
 
+        if ( $this->getCreationDate() === true )
+        {
+            array_push( $resultstring, date( 'c', $collection->attribute( 'created' ) ) );
+        }
+
+        if ( $this->getModificationDate() === true )
+        {
+            array_push( $resultstring, date( 'c', $collection->attribute( 'modified' ) ) );
+        }
+
         return $resultstring;
     }
 
@@ -229,10 +258,21 @@ class Parser
         $attributes_to_export,
         $seperationChar,
         $export_type = 'csv',
-        $days
+        $days,
+        $creation_date = false,
+        $modification_date = false
     )
     {
         // eZDebug::writeDebug( $attributes_to_export );
+        if ( $creation_date !== false )
+        {
+            $this->setCreationDate( true );
+        }
+
+        if ( $modification_date !== false )
+        {
+            $this->setModificationDate( true );
+        }
 
         switch ( $export_type )
         {
@@ -616,6 +656,24 @@ class Parser
         }
     }
 
+    public function setModificationDate( $date )
+    {
+        $this->modificationDate = $date;
+    }
+
+    public function setCreationDate( $date )
+    {
+        $this->creationDate = $date;
+    }
+
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+    public function getModificationDate()
+    {
+        return $this->modificationDate;
+    }
 }
 
 ?>

--- a/design/standard/templates/bccie/export.tpl
+++ b/design/standard/templates/bccie/export.tpl
@@ -54,7 +54,7 @@
 <input name="end_year" class="box" size="5" value="{$end_year|wash}" />
 </div>
 </div>
-<div align="right"> 
+<div align="right">
 {section show=$collection_array}
 <input class="button" style="position:relative;top:-10px;" type="submit" name="DoExport" value="{'Do export'|i18n( 'design/bccie/export' )}" title="{'Do export.'|i18n( 'design/bccie/export' )}" />
 {section-else}
@@ -70,6 +70,22 @@
 <div class="break"></div>
 </div>
 </div>
+
+{*export create and modification date*}
+<fieldset>
+    <legend>{'Export creation and modification date'|i18n( 'design/bccie/export' )}</legend>
+    <div class="block">
+        <div class="element">
+            {'Export Creation Date'|i18n( 'design/bccie/export' )}:
+            <input name="creation_date" type="checkbox" value="1" />
+        </div>
+        <div class="element">
+            {'Export Modification Date'|i18n( 'design/bccie/export' )}:
+            <input name="modification_date" type="checkbox" value="1" />
+        </div>
+    </div>
+    <div class="break"></div>
+</fieldset>
 
 {* Collection table. *}
 {let counter=0}
@@ -99,7 +115,7 @@
                                 <legend>{'Field #%counter'|i18n('design/bccie/export',, hash( '%counter', $counter) )}</legend>
                                     <select name="field_{$counter}">
                                         <option selected="selected" value="contentobjectid">Content object id</option>
-                                
+
                                         {section loop=$class.data_map}
                                                 {let current_inner_attribute=$:item}
                                                         {section show=$current_inner_attribute.is_information_collector }
@@ -118,7 +134,7 @@
                                 {set counter=inc( $counter )}
                         {/section}
                 {/let}
-                
+
         {/section}
 {/let}
 {/let}

--- a/design/standard/templates/bccie/export.tpl
+++ b/design/standard/templates/bccie/export.tpl
@@ -71,7 +71,7 @@
 </div>
 </div>
 
-{*export create and modification date*}
+{* export create and modification date *}
 <fieldset>
     <legend>{'Export creation and modification date'|i18n( 'design/bccie/export' )}</legend>
     <div class="block">

--- a/doc/FAQ
+++ b/doc/FAQ
@@ -1,3 +1,20 @@
 BC CIE extension FAQ
 
 
+CUSTOM DATATYPES:
+
+The following custom datatypes are also supported by this extension:
+
+- smileobjectrelationlistdatatype (https://github.com/arbito82/smileobjectrelationlistdatatype)
+
+
+PLATFORM SPECIFIC NOTES:
+
+There was a UTF-8 encoding problem with opening files in excel on a mac. Therefore the following modification was made:
+
+modules/bccie/doexport.php
+-echo( $export_string );
++print chr(255) . chr(254) . mb_convert_encoding($export_string, 'UTF-16LE', 'UTF-8');
+
+More information on this issue can be found here:
+http://stackoverflow.com/questions/4348802/how-can-i-output-a-utf-8-csv-in-php-that-excel-will-read-properly

--- a/modules/bccie/doexport.php
+++ b/modules/bccie/doexport.php
@@ -20,6 +20,8 @@ $http = eZHTTPTool::instance();
 $module = $Params['Module'];
 $objectID = $Params['ObjectID'];
 $object = false;
+$creationDate = false;
+$modificationDate = false;
 
 if ( is_numeric( $objectID ) )
 {
@@ -75,6 +77,17 @@ elseif ( $start === false and $end !== false )
 {
     $conditions['created'] = array( '<', $end );
 }
+
+if ( $http->hasPostVariable( "creation_date" ) )
+{
+   $creationDate = true;
+}
+
+if ( $http->hasPostVariable( "modification_date" ) )
+{
+   $modificationDate = true;
+}
+
 set_time_limit( 180 );
 $collections = eZPersistentObject::fetchObjectList(
                                  eZInformationCollection::definition(),
@@ -130,7 +143,9 @@ $export_string = $parser->exportInformationCollection(
                             $attributes_to_export,
                             $seperation_char,
                             $export_type,
-                            $days
+                            $days,
+                            $creationDate,
+                            $modificationDate
 );
 
 print chr(255) . chr(254) . mb_convert_encoding($export_string, 'UTF-16LE', 'UTF-8');

--- a/modules/bccie/doexport.php
+++ b/modules/bccie/doexport.php
@@ -20,8 +20,8 @@ $http = eZHTTPTool::instance();
 $module = $Params['Module'];
 $objectID = $Params['ObjectID'];
 $object = false;
-$creationDate = false;
-$modificationDate = false;
+$exportCreationDate = false;
+$exportModificationDate = false;
 
 if ( is_numeric( $objectID ) )
 {
@@ -80,12 +80,12 @@ elseif ( $start === false and $end !== false )
 
 if ( $http->hasPostVariable( "creation_date" ) )
 {
-   $creationDate = true;
+   $exportCreationDate = true;
 }
 
 if ( $http->hasPostVariable( "modification_date" ) )
 {
-   $modificationDate = true;
+   $exportModificationDate = true;
 }
 
 set_time_limit( 180 );
@@ -144,8 +144,8 @@ $export_string = $parser->exportInformationCollection(
                             $seperation_char,
                             $export_type,
                             $days,
-                            $creationDate,
-                            $modificationDate
+                            $exportCreationDate,
+                            $exportModificationDate
 );
 
 print chr(255) . chr(254) . mb_convert_encoding($export_string, 'UTF-16LE', 'UTF-8');

--- a/modules/bccie/doexport.php
+++ b/modules/bccie/doexport.php
@@ -125,8 +125,6 @@ switch ( $export_type )
 
 header( "Content-Disposition: attachment; filename=$filename" );
 
-echo "\xEF\xBB\xBF";
-
 $export_string = $parser->exportInformationCollection(
                         $collections,
                             $attributes_to_export,
@@ -135,7 +133,7 @@ $export_string = $parser->exportInformationCollection(
                             $days
 );
 
-echo( $export_string );
+print chr(255) . chr(254) . mb_convert_encoding($export_string, 'UTF-16LE', 'UTF-8');
 
 flush();
 

--- a/settings/export.ini.append.php
+++ b/settings/export.ini.append.php
@@ -18,6 +18,7 @@ ExportableDatatypes[]=ezcountry
 ExportableDatatypes[]=eztime
 ExportableDatatypes[]=ezdate
 ExportableDatatypes[]=ezdatetime
+ExportableDatatypes[]=smileobjectrelationlist
 
 
 # All handlerfiles are sought in the base directory,
@@ -91,5 +92,9 @@ HandlerClass=eZTimeHandler
 [ezdate]
 HandlerFile=ezdatehandler.php
 HandlerClass=eZDateHandler
+
+[smileobjectrelationlist]
+HandlerFile=smileobjectrelationlisthandler.php
+HandlerClass=smileobjectrelationlistHandler
 
 */ ?>

--- a/translations/ger-DE/translation.ts
+++ b/translations/ger-DE/translation.ts
@@ -92,5 +92,9 @@
         <source>modified</source>
         <translation>geändert</translation>
     </message>
+    <message>
+        <source>Export creation and modification date</source>
+        <translation>Erstellungsdatum und Änderungsdatum exportieren</translation>
+    </message>
 </context>
 </TS>

--- a/translations/ger-DE/translation.ts
+++ b/translations/ger-DE/translation.ts
@@ -71,6 +71,26 @@
     <message>
         <source>Do export</source>
         <translation>Exportieren</translation>
-    </message>    
+    </message>
+    <message>
+        <source>Export Creation Date</source>
+        <translation>Erstellungsdatum exportieren</translation>
+    </message>
+    <message>
+        <source>Export Modification Date</source>
+        <translation>Änderungsdatum exportieren</translation>
+    </message>
+    <message>
+        <source>Export Modification Date</source>
+        <translation>Änderungsdatum exportieren</translation>
+    </message>
+    <message>
+        <source>created</source>
+        <translation>erstellt</translation>
+    </message>
+    <message>
+        <source>modified</source>
+        <translation>geändert</translation>
+    </message>
 </context>
 </TS>


### PR DESCRIPTION
There is an encoding problem if you want to open files in excel on a mac. 

http://stackoverflow.com/questions/4348802/how-can-i-output-a-utf-8-csv-in-php-that-excel-will-read-properly

This fix works. You can open it in excel an a mac now too.